### PR TITLE
update 85 and updated version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='undetected-chromedriver',
-    version='1.3.0',
+    version='1.3.5',
     packages=['undetected_chromedriver'],
     install_requires=[
         'selenium',


### PR DESCRIPTION
small behaviour change:  the current release version will be looked up online, unless you specify TARGET_VERSION, or have target_version set as a parameter to ChromeDriverManager. Nothing will change if you already have chromedriver.exe in place in your project (so it won't suddenly jump versions).