### PR TITLE
console log disabled by default, added keyword param to manually enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 https://github.com/ultrafunkamsterdam/undetected-chromedriver
 
-Optimized Selenium Chromedriver patch which does not trigger anti-bot services like Distill Network.
+Optimized Selenium Chromedriver patch which does not trigger anti-bot services like Distill Network / Imperva / DataDome / Botprotect.io
 Automatically downloads the driver binary and patches it.
 
 * **Tested on version 75,76,77,78,79,80,81,83,84,85,86**
 
 * **patching also works on MS Edge (chromium-based) webdriver binary**
 
+## New ##
+
+By default, the console log function is disabled to prevent certain detections.
+Until a cleaner solution is found, use the following to manually enable it
+
+```python
+import undetected_chromedriver as uc
+driver = uc.Chrome(enable_console_log=True)
+```
 
 ## Installation ##
 ```

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name="undetected-chromedriver",
-    version="1.3.7",
+    version="1.4.0",
     packages=["undetected_chromedriver"],
     install_requires=["selenium",],
     url="https://github.com/ultrafunkamsterdam/undetected_chromedriver",
@@ -24,7 +24,7 @@ setup(
     author="UltrafunkAmsterdam",
     author_email="info@blackhat-security.nl",
     description="""
-                Optimized Selenium/Chromedriver drop-in replacement for selenium.webdriver, using the same interface for Chrome and ChromeOptions, but which does NOT trigger anti-bot services like Distil / Imperva / DataDome and such.
+                Optimized Selenium/Chromedriver drop-in replacement for selenium.webdriver, using the same interface for Chrome and ChromeOptions, but which does NOT trigger anti-bot services like Distil / Imperva / DataDome / Botprotect.io and such.
                 All required anti-detection settings are built-in, yet overridable if you\'d really want. Be aware: any customization in settings could potentially trigger detection,
                 For more information check out the README.""",
     long_description=open("README.md").read(),

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -35,7 +35,7 @@ TARGET_VERSION = 0
 
 
 class Chrome:
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, enable_console_log=False, **kwargs):
 
         if not ChromeDriverManager.installed:
             ChromeDriverManager(*args, **kwargs).install()
@@ -63,8 +63,10 @@ class Chrome:
                   ? target[key].bind(target)
                   : target[key]
             })
-        })
+        });
                   """
+                          + "console.dir = console.log = function(){};" 
+                          if not enable_console_log else ''
             },
         )
         original_user_agent_string = instance.execute_script(


### PR DESCRIPTION
Until a cleaner solution is found:

console log disabled by default to prevent certain detections. To override, use ```uc.Chrome(enable_console_log=True).```