### PR TITLE
Set a Download Path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     version="1.5.0",
     packages=["undetected_chromedriver"],
     install_requires=["selenium",],
-    url="https://github.com/ultrafunkamsterdam/undetected_chromedriver",
+    url="https://github.com/ultrafunkamsterdam/undetected-chromedriver",
     license="GPL-3.0",
     author="UltrafunkAmsterdam",
     author_email="info@blackhat-security.nl",


### PR DESCRIPTION
### Changes
- Added the ability to set a `download_path` for `Chrome` and `ChromeOptions`. 
    - A specific example where this would be useful is running on `AWS Lambda` where the
    default download location is forbidden.
     
#### Found Bugs:
- Using `uc.ChromeOptions()` with a custom `executable_path` requires setting it for
both the `ChromeOptions` and `Chrome` objects, otherwise it will still be downloaded 
in the default directory.
    - Temporary Fix: Set the `executable_path` on both `ChromeOptions` and `Chrome`.
        - This will also work for the `download_path` proposed revision.