### PR TITLE
Add randomize string to patch_binary

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -105,6 +105,7 @@ class ChromeOptions:
         instance.add_argument("start-maximized")
         instance.add_experimental_option("excludeSwitches", ["enable-automation"])
         instance.add_argument("--disable-blink-features=AutomationControlled")
+        instance.add_argument('--log-level=%d' % divmod(logger.getEffectiveLevel(), 10)[0])
         return instance
 
 


### PR DESCRIPTION
Changes:

- Patch binary regardless of whether the chromdriver is patched or not.
- Set self.__class__.installed as True after binary patching regardless of whether the binary got patched or not, to avoid multiple installs when calling uc.install() and webdriver.Chrome().
- Patch the binary using a randomized string, and save it at the same directory as the chromdriver, for the next patching process.