### PR TITLE
Add integration, static style test for module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# patched chromedriver
+chromedriver

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ d88P"    888 "88b 888P"  d88""88b 888 "888 "88b d8P  Y8b d88" 888 888P"   888 88
 Y88b.    888  888 888    Y88..88P 888  888  888 Y8b.     Y88b 888 888     888  Y8bd8P  Y8b.     888
  "Y8888P 888  888 888     "Y88P"  888  888  888  "Y8888   "Y88888 888     888   Y88P    "Y8888  888   88888888
 
-BY ULTRAFUNKAMSTERDAM (https://github.com/ultrafunkamsterdam)"""
+BY ULTRAFUNKAMSTERDAM (https://github.com/ultrafunkamsterdam)
+# noqa
+"""
 
 from setuptools import setup
 
@@ -18,7 +20,9 @@ setup(
     name="undetected-chromedriver",
     version="2.2.1",
     packages=["undetected_chromedriver"],
-    install_requires=["selenium",],
+    install_requires=[
+        "selenium",
+    ],
     url="https://github.com/ultrafunkamsterdam/undetected-chromedriver",
     license="GPL-3.0",
     author="UltrafunkAmsterdam",
@@ -26,8 +30,9 @@ setup(
     description="""\
     selenium.webdriver.Chrome replacement with focus on stealth.
     not triggered by Distil / CloudFlare / Imperva / DataDome / hCaptcha and such.
-    
-    NOTE: results may vary due to many factors. No guarantees are given, except for ongoing efforts in understanding detection algorithms.
+
+    NOTE: results may vary due to many factors. No guarantees are given, except for
+    ongoing efforts in understanding detection algorithms.
     """,
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -37,4 +42,3 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
 )
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from _pytest.fixtures import FixtureRequest
+import undetected_chromedriver as uc
+
+FAILED_SCREENSHOT_NAME = "failed.png"
+
+
+@pytest.fixture
+def head_uc(request: FixtureRequest):
+    request.instance.driver = uc.Chrome()
+
+    def teardown():
+        request.instance.driver.save_screenshot(FAILED_SCREENSHOT_NAME)
+        request.instance.driver.quit()
+
+    request.addfinalizer(teardown)
+
+    return request.instance.driver
+
+
+@pytest.fixture
+def headless_uc(request: FixtureRequest):
+    options = uc.ChromeOptions()
+    options.headless = True
+    request.instance.driver = uc.Chrome(options=options)
+
+    def teardown():
+        request.instance.driver.save_screenshot(FAILED_SCREENSHOT_NAME)
+        request.instance.driver.quit()
+
+    request.addfinalizer(teardown)
+
+    return request.instance.driver

--- a/tests/test_undetected_chromedriver.py
+++ b/tests/test_undetected_chromedriver.py
@@ -9,28 +9,28 @@ import time  # noqa
 def test_undetected_chromedriver():
 
     import undetected_chromedriver.v2 as uc
+
     driver = uc.Chrome()
-    
+
     with driver:
         driver.get("https://coinfaucet.eu")
-    time.sleep(4) # sleep only used for timing of screenshot
+    time.sleep(4)  # sleep only used for timing of screenshot
     driver.save_screenshot("coinfaucet.eu.png")
 
     with driver:
         driver.get("https://cia.gov")
-    time.sleep(4) # sleep only used for timing of screenshot
+    time.sleep(4)  # sleep only used for timing of screenshot
     driver.save_screenshot("cia.gov.png")
 
     with driver:
         driver.get("https://lhcdn.botprotect.io")
-    time.sleep(4) # sleep only used for timing of screenshot
+    time.sleep(4)  # sleep only used for timing of screenshot
     driver.save_screenshot("notprotect.io.png")
 
     with driver:
         driver.get("https://www.datadome.co")
-    time.sleep(4) # sleep only used for timing of screenshot
+    time.sleep(4)  # sleep only used for timing of screenshot
     driver.save_screenshot("datadome.co.png")
 
 
 test_undetected_chromedriver()
-

--- a/tests/v1/head_test.py
+++ b/tests/v1/head_test.py
@@ -1,0 +1,20 @@
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+TIMEOUT = 10
+
+
+@pytest.mark.usefixtures("head_uc")
+class TestBotCheck:
+    def test_bot_protect_io(self):
+        driver: WebDriver = self.driver  # type: ignore
+        driver.get("https://lhcdn.botprotect.io")
+        msg = WebDriverWait(driver, TIMEOUT).until(
+            EC.visibility_of_element_located((By.ID, "msg"))
+        )
+        print(msg.text)
+        assert "You are human." in msg.text

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist =
+    py38,
+    static_check,
+    v1,
+    v2
+
+[testenv]
+deps =
+    pytest
+    selenium
+
+[testenv:static_check]
+deps =
+    black
+    flake8
+commands =
+    black --check --diff .
+    flake8 undetected_chromedriver \
+        --max-line-length=88 \
+        --exclude v2.py
+
+[testenv:v1]
+commands =
+    pytest \
+        -v -s \
+        ./tests/v1
+
+; Currently v2 is WIP
+; [testenv:v2]
+; commands =
+;     pytest \
+;         -v -s \
+;         ./tests/v2

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -13,7 +13,7 @@ Y88b.    888  888 888    Y88..88P 888  888  888 Y8b.     Y88b 888 888     888  Y
  "Y8888P 888  888 888     "Y88P"  888  888  888  "Y8888   "Y88888 888     888   Y88P    "Y8888  888   88888888
 
 by UltrafunkAmsterdam (https://github.com/ultrafunkamsterdam)
-
+# noqa
 """
 
 import io
@@ -72,7 +72,7 @@ class Chrome:
                                            : target[key]
                                        })
                                    });
-                               """
+                               """  # noqa: E501
                     },
                 )
             return instance._orig_get(*args, **kwargs)
@@ -160,7 +160,7 @@ class ChromeDriverManager(object):
         self.executable_path = executable_path or exe_name
         self._exe_name = exe_name
 
-    def patch_selenium_webdriver(self_):
+    def patch_selenium_webdriver(self):
         """
         Patches selenium package Chrome, ChromeOptions classes for current session
 
@@ -172,7 +172,7 @@ class ChromeDriverManager(object):
         selenium.webdriver.Chrome = Chrome
         selenium.webdriver.ChromeOptions = ChromeOptions
         logger.info("Selenium patched. Safe to import Chrome / ChromeOptions")
-        self_.__class__.selenium_patched = True
+        self.__class__.selenium_patched = True
 
     def install(self, patch_selenium=True):
         """
@@ -183,7 +183,8 @@ class ChromeDriverManager(object):
          patch the downloaded chromedriver
          patch selenium package if <patch_selenium> is True (default)
 
-        :param patch_selenium: patch selenium webdriver classes for Chrome and ChromeDriver (for current python session)
+        :param patch_selenium: patch selenium webdriver classes for Chrome and
+            ChromeDriver (for current python session)
         :return:
         """
         if not os.path.exists(self.executable_path):
@@ -197,7 +198,8 @@ class ChromeDriverManager(object):
 
     def get_release_version_number(self):
         """
-        Gets the latest major version available, or the latest major version of self.target_version if set explicitly.
+        Gets the latest major version available, or the latest major version of
+            self.target_version if set explicitly.
 
         :return: version string
         """

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -37,7 +37,7 @@ TARGET_VERSION = 0
 
 
 class Chrome:
-    def __new__(cls, *args, emulate_touch=False, **kwargs):
+    def __new__(cls, *args, emulate_touch=False, **kwargs) -> _Chrome:
 
         if not ChromeDriverManager.installed:
             ChromeDriverManager(*args, **kwargs).install()
@@ -105,7 +105,7 @@ class Chrome:
 
 
 class ChromeOptions:
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> _ChromeOptions:
         if not ChromeDriverManager.installed:
             ChromeDriverManager(*args, **kwargs).install()
         if not ChromeDriverManager.selenium_patched:

--- a/undetected_chromedriver/v2.py
+++ b/undetected_chromedriver/v2.py
@@ -4,7 +4,7 @@
 """
 V2 beta
 
-whats new: 
+whats new:
 
     - currently this v2 module will be available as option.
       to use it / test it, you need to alter your imports by appending .v2
@@ -20,7 +20,7 @@ whats new:
 
     # if site is protected by hCaptcha/Cloudflare
     driver.get_in('https://cloudflareprotectedsite.xyz')
-    
+
     # if site is protected by hCaptcha/Cloudflare
     # (different syntax, same function)
     with driver:
@@ -44,11 +44,8 @@ import string
 import subprocess
 import sys
 import tempfile
-import threading
 import time
 import zipfile
-import atexit
-import contextlib
 from distutils.version import LooseVersion
 from urllib.request import urlopen, urlretrieve
 
@@ -101,11 +98,11 @@ class Chrome(object):
     __doc__ = (
         """\
     --------------------------------------------------------------------------
-    NOTE: 
+    NOTE:
     Chrome has everything included to work out of the box.
     it does not `need` customizations.
     any customizations MAY lead to trigger bot migitation systems.
-    
+
     --------------------------------------------------------------------------
     """
         + selenium.webdriver.remote.webdriver.WebDriver.__doc__
@@ -234,7 +231,7 @@ class Chrome(object):
                                     enumerable: true,
                                         get: () => {
                                             return "unknown"
-                                        },       
+                                        },
                                     });
                             """
                         },


### PR DESCRIPTION
* Improve the style to match PEP8 by using black & flake8 to auto format & test.
* Add test for head-uc-v1, botprotect.io site

Some notes:
* botprotect.io site will fail on headless v1. I know that you don't support it (yet), so I don't add this test, but the fixture is ready to be used.
* datadome.co: v1 works on both head or headless, but I got my IP blacklisted so I cannot test further, so I didn't add this test. TODO.
* Other sites: does not block me on normal chromedriver (CIA for example), or blocks me everytime because I do not live in EU (coinfaucet.eu), so I cannot add test

TODO:
* Add test for datadome when I change my IP
* Add github action flow, using CI/CD pipeline to do format check & integration test if we have pull request or push
* Add more documents on testing via tox
