### PR TITLE
Added flag to keep existing webdriver binary.

### DIFF
--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -43,7 +43,7 @@ class Patcher(object):
         d = "~/.undetected_chromedriver"
     data_path = os.path.abspath(os.path.expanduser(d))
 
-    def __init__(self, executable_path=None, force=False, version_main: int = 0):
+    def __init__(self, executable_path=None, force=False, version_main: int = 0, keep_webdriver_file=False):
         """
 
         Args:
@@ -56,6 +56,7 @@ class Patcher(object):
         """
 
         self.force = force
+        self.keep_webdriver_file = keep_webdriver_file
 
         if not executable_path:
             executable_path = os.path.join(self.data_path, self.exe_name)
@@ -98,10 +99,14 @@ class Patcher(object):
         except FileNotFoundError:
             pass
 
-        release = self.fetch_release_number()
-        self.version_main = release.version[0]
-        self.version_full = release
-        self.unzip_package(self.fetch_package())
+        # If the binary exists and keep_webdriver_file was set to True,
+        # then no there is need to download it again
+        if not (os.path.exists(self.executable_path) and self.keep_webdriver_file):
+            release = self.fetch_release_number()
+            self.version_main = release.version[0]
+            self.version_full = release
+            self.unzip_package(self.fetch_package())
+        
         # i.patch()
         return self.patch()
 

--- a/undetected_chromedriver/v2.py
+++ b/undetected_chromedriver/v2.py
@@ -82,6 +82,7 @@ class Chrome(selenium.webdriver.Chrome):
         delay=5,
         version_main=None,
         patcher_force_close=False,
+        keep_webdriver_file=False,
     ):
         """
         Creates a new instance of the chrome driver.
@@ -148,7 +149,7 @@ class Chrome(selenium.webdriver.Chrome):
             setting it is not recommended, unless you know the implications and think
             you might need it.
         """
-        patcher = Patcher(executable_path=executable_path, force=patcher_force_close, version_main=version_main)
+        patcher = Patcher(executable_path=executable_path, force=patcher_force_close, version_main=version_main, keep_webdriver_file=keep_webdriver_file)
         patcher.auto()
 
         if not options:


### PR DESCRIPTION
This might be a niche use case, but if a fast startup is needed, then downloading the webdriver binary each time the script runs may take too long, due to slower connections and such.

So the ```keep_webdriver_file``` parameter in the ```Chrome``` and ```Patcher``` classes tells the patcher to only download the binary if it doesn't exist, or this flag is False.