### PR TITLE
Dependency fix for Python 3.10

### DIFF
--- a/undetected_chromedriver/cdp.py
+++ b/undetected_chromedriver/cdp.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import requests
 import websockets


### PR DESCRIPTION
`collections.abc` houses the legacy classes _Mapping_ and _Sequence_

This fixes the `cannot import name 'Mapping' from 'collections'`  bug for Python 3.10.

![image](https://user-images.githubusercontent.com/74636869/132017290-e50d48f8-1a42-4158-a291-84550bc5a9e0.png)
