### PR TITLE
Remove unused "collections" import.

### DIFF
--- a/undetected_chromedriver/cdp.py
+++ b/undetected_chromedriver/cdp.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-from collections import Mapping, Sequence
 
 import requests
 import websockets


### PR DESCRIPTION
Duplicate of #294
Fixes issue #341

As suggested by @FastestMolasses in #294, I removed the unused import. This change makes the package work under Python3.10.