### PR TITLE
bugfix - added a flag use_subprocess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,11 @@ setup(
     description="""\
     selenium.webdriver.Chrome replacement wiht compatiblity for Brave, and other Chromium baed browsers.
     not triggered by CloudFlare/Imperva/hCaptcha and such.
-    
     NOTE: results may vary due to many factors. No guarantees are given, except for ongoing efforts in understanding detection algorithms.
     """,
-    long_description=open(os.path.join(dirname, "README.md"),encoding="utf-8").read(),
+
+    long_description=open(os.path.join(dirname, "README.md"), encoding="utf-8").read(),
+
     long_description_content_type="text/markdown",
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -57,6 +58,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -113,7 +113,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         version_main=None,
         patcher_force_close=False,
         suppress_welcome=True,
-        no_subprocess=True,
+        use_subprocess=False,
         debug=False,
         **kw
     ):

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -536,7 +536,8 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
     def quit(self):
         logger.debug("closing webdriver")
-        self.service.process.kill()
+        if hasattr(self, 'service') and getattr(self.service, 'process', None):
+                  self.service.process.kill()
         try:
             if self.reactor and isinstance(self.reactor, Reactor):
                 logger.debug("shutting down reactor")


### PR DESCRIPTION
There was an edge case where users complained about.
While we all  rather have chrome running without parent process (for detection purposes), 
some users don't want that, and rather complained about an Error which was thrown that their program exited before Chome started effectively.
So instead them writing a longer program, using an interactive session, or write if __name__  == '__main__' ,
I created this flag. Those users should explicitly set it to True. 
Detections when using this are NOT supported.