### PR TITLE
fix executable_path for custom chromedriver

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -100,7 +100,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
     def __init__(
         self,
         user_data_dir=None,
-        browser_executable_path=None,
+        executable_path=None,
         port=0,
         options=None,
         enable_cdp_events=False,
@@ -129,9 +129,8 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             if user_data_dir is a path to a valid chrome profile directory, use it,
             and turn off automatic removal mechanism at exit.
 
-        browser_executable_path: str, optional, default: None - use find_chrome_executable
-            Path to the browser executable.
-            If not specified, make sure the executable's folder is in $PATH
+        executable_path: str, optional, default: None - path to custom chromedriver
+            If not specified, UC will download it automatically
 
         port: int, optional, default: 0
             port you would like the service to run, if left as 0, a free port will be found.
@@ -205,7 +204,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         """
         self.debug = debug
         patcher = Patcher(
-            executable_path=None,
+            executable_path=executable_path,
             force=patcher_force_close,
             version_main=version_main,
         )
@@ -487,7 +486,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 "source": """
                     let objectToInspect = window,
                         result = [];
-                    while(objectToInspect !== null) 
+                    while(objectToInspect !== null)
                     { result = result.concat(Object.getOwnPropertyNames(objectToInspect));
                       objectToInspect = Object.getPrototypeOf(objectToInspect); }
                     result.forEach(p => p.match(/.+_.+_(Array|Promise|Symbol)/ig)


### PR DESCRIPTION
browser_executable_path isn't necessary here, because it is defined by binary_location in options argument.

In other hand, chromedriver executable path is missing for patcher. There is no way to set custom chromedriver path. Without executable_path, undetected_chromedriver will alway download chromedriver from its repo and then patch it also.