### PR TITLE
Patcher/Browser: allow for custom chromedriver binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ Automatically downloads the driver binary and patches it.
   
   
 
-### psst, skilled users... there is a 3.1.0rc out to be tested. ! breaking changes ! ##
-- please read before use.
-- https://pypi.org/project/undetected-chromedriver/3.1.0rc1/
-
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dirname = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(
     os.path.join(dirname, "undetected_chromedriver", "__init__.py"),
     mode="r",
-    encoding="latin1",
+    encoding="utf-8",
 ) as fp:
     try:
         version = re.findall(r"^__version__ = ['\"]([^'\"]*)['\"]", fp.read(), re.M)[0]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     
     NOTE: results may vary due to many factors. No guarantees are given, except for ongoing efforts in understanding detection algorithms.
     """,
-    long_description=open(os.path.join(dirname, "README.md")).read(),
+    long_description=open(os.path.join(dirname, "README.md"),encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -56,7 +56,7 @@ class Patcher(object):
         """
 
         self.force = force
-        self.executable_path = None
+        self.executable_path = executable_path
 
         if not executable_path:
             self.executable_path = os.path.join(self.data_path, self.exe_name)


### PR DESCRIPTION
This allows for chromedriver binary to be loaded from a user-defined location, allowing multiple instances of undetected_chromedriver to be start at the same time, without all of them trying to download and patch the chromedriver to the same location which resulted in only the first instance to be started to actually start, and the others crashing.