### PR TITLE
3.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
 )

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -669,7 +669,10 @@ def find_chrome_executable():
                 candidates.add(os.sep.join((item, subitem)))
         if "darwin" in sys.platform:
             candidates.update(
-                ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+                [
+                  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                  "/Applications/Chromium.app/Contents/MacOS/Chromium"
+                ]
             )
     else:
         for item in map(
@@ -679,6 +682,7 @@ def find_chrome_executable():
                 "Google/Chrome/Application",
                 "Google/Chrome Beta/Application",
                 "Google/Chrome Canary/Application",
+                   
             ):
                 candidates.add(os.sep.join((item, subitem, "chrome.exe")))
     for candidate in candidates:

--- a/undetected_chromedriver/webelement.py
+++ b/undetected_chromedriver/webelement.py
@@ -36,4 +36,4 @@ class WebElement(selenium.webdriver.remote.webelement.WebElement):
         strattrs = " ".join([f'{k}="{v}"' for k, v in self.attrs.items()])
         if strattrs:
             strattrs = " " + strattrs
-        return f"<{self.__class__.__name__}(<{self.tag_name}{strattrs}>)>"
+        return f"{self.__class__.__name__} <{self.tag_name}{strattrs}>"

--- a/undetected_chromedriver/webelement.py
+++ b/undetected_chromedriver/webelement.py
@@ -1,0 +1,40 @@
+import selenium.webdriver.remote.webelement
+
+
+class WebElement(selenium.webdriver.remote.webelement.WebElement):
+    """
+    Custom WebElement class which makes it easier to view elements when
+    working in an interactive environment.
+
+    standard webelement repr:
+    <selenium.webdriver.remote.webelement.WebElement (session="85ff0f671512fa535630e71ee951b1f2", element="6357cb55-92c3-4c0f-9416-b174f9c1b8c4")>
+
+    using this WebElement class:
+    <WebElement(<a class="mobile-show-inline-block mc-update-infos init-ok" href="#" id="main-cat-switcher-mobile">)>
+
+    """
+    _attrs = {}
+
+    @property
+    def attrs(self):
+        if not hasattr(self, "_attrs"):
+            self._attrs = self._parent.execute_script(
+                """
+                var items = {}; 
+                for (index = 0; index < arguments[0].attributes.length; ++index) 
+                {
+                 items[arguments[0].attributes[index].name] = arguments[0].attributes[index].value 
+                }; 
+                return items;
+                """,
+                self,
+            )
+        return self._attrs
+
+    def __repr__(self):
+        strattrs = " ".join([f'{k}="{v}"' for k, v in self.attrs.items()])
+        if strattrs:
+            strattrs = " " + strattrs
+        return f"<{self.__class__.__name__}(<{self.tag_name}{strattrs}>)>"
+
+


### PR DESCRIPTION

## Patcher ##
    changed the way how patcher works (for those using multiple sessions/processes).

    when not specifying a executable_path (the default, and recommended!), the filename
    gets randomized to <somehex>_chromedriver[.exe]. this should fix the issue for multiprocessing 
    (although Chrome/driver itself has restrictions in this as well, see it using processhacker).
    As i told before, webdriver is a purely io-based operation which only sends and pulls data. multiprocessing/threading isn't going to help much. You'd better use asyncio.)


## find_chrome_executable ##
    added google-chrome-stable to the list, as some distro's have this name.
    also added chromium for MacOS as per request


##  advanced_webelements ## 
 Chrome(advanced_elements)bool, optional, default: False
 
        makes it easier to recognize elements like you know them from html/browser inspection, especially when working in an interactive environment

        default webelement repr:
        <selenium.webdriver.remote.webelement.WebElement (session="85ff0f671512fa535630e71ee951b1f2", element="6357cb55-92c3-4c0f-9416-b174f9c1b8c4")>

        advanced webelement repr
        <WebElement(<a class="mobile-show-inline-block mc-update-infos init-ok" href="#" id="main-cat-switcher-mobile">)>

    note: when retrieving large amounts of elements ( example: find_elements_by_tag("*") ) and **print** them, it does take a little more time for all the repr's to fetch


## Chrome() parameters ##

**driver_executable_path=None** 
also known as executable_path
    if you really need to specify your own chromedriver binary.
    (don't log issues when you are not using the default. the downloading per session happens for a reason. remember this is a detection-focussed fork)
    

**browser_executable_path=None**
        ( = browser binary path )
    to specify your browser in case you use exotic locations instead of the more default install folders

**clean quick script added for windows users to test cloudflare**
   it creates a clean environment, installs undetected-chromedriver, and runs UC with (debug) settings. After that, it removes the environment. If it fails, you are likely having some IP reputation
  
 **advanced_elements=False**
        if set to True, webelements get a nicer REPR showing. this is very convenient when working 
        interactively (like ipython for example).

        <WebElement(<a class="mobile-show-inline-block mc-update-infos init-ok" href="#" id="main-cat-switcher-mobile">)>
        
        instead of

        <selenium.webdriver.remote.webelement.WebElement (session="85ff0f671512fa535630e71ee951b1f2",element="6357cb55-92c3-4c0f-9416-b174f9c1b8c4")>

