### PR TITLE
3.1.6 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,23 @@ Automatically downloads the driver binary and patches it.
 * Works also on Brave Browser and many other Chromium based browsers, some tweaking
 * Python 3.6++**
 
-### 3.1.0 ####
+
+### 3.1.6 ###
+### still passing strong ###
+
+- use_subprocess now defaults to True. too many people don't understand multiprocessing and __name__ == '__main__, and after testing, it seems not to make a difference anymore in chrome 104+
+
+- added no_sandbox, which defaults to True, and this without the annoying "you are using unsecure command line ..." bar.
+
+- update [Docker image](https://hub.docker.com/r/ultrafunk/undetected-chromedriver).
+  you can now vnc or rdp into your container to see the actual browser window
+[![demo](https://i.imgur.com/51Ang6R.gif)](https://i.imgur.com/W7vriN9.mp4)
+
+- of course, "regular" mode works as well
+[![demo](https://i.imgur.com/2qSNyuK.gif)](https://i.imgur.com/2qSNyuK.mp4)
+
+
+### 3.1.0 ###
 
   **this version `might` break your code, test before update!**
 
@@ -91,42 +107,38 @@ To prevent unnecessary hair-pulling and issue-raising, please mind the **[import
 
 <br>
 
-### The Version 2 way ###
+### easy ###
 Literally, this is all you have to do. 
 Settings are included and your browser executable is found automagically.
 This is also the snippet i recommend using in case you experience an issue.
 ```python
 import undetected_chromedriver.v2 as uc
 driver = uc.Chrome()
-driver.get('https://nowsecure.nl')  # known url using cloudflare's "under attack mode"
+driver.get('https://nowsecure.nl')  # my own test test site with max anti-bot protection
 ```
 
-### The Version 2 more advanced way, including setting profie folder ###
+### more advanced way, including setting profie folder ###
 Literally, this is all you have to do. 
 If a specified folder does not exist, a NEW profile is created.
 Data dirs which are specified like this will not be autoremoved on exit.
 
 
 ```python
-import undetected_chromedriver.v2 as uc
+import undetected_chromedriver as uc
 options = uc.ChromeOptions()
 
 # setting profile
 options.user_data_dir = "c:\\temp\\profile"
 
-# another way to set profile is the below (which takes precedence if both variants are used
-options.add_argument('--user-data-dir=c:\\temp\\profile2')
-
-# just some options passing in to skip annoying popups
-options.add_argument('--no-first-run --no-service-autorun --password-store=basic')
+# use specific (older) version
 driver = uc.Chrome(options=options, version_main=94)  # version_main allows to specify your chrome version instead of following chrome global version
 
-driver.get('https://nowsecure.nl')  # known url using cloudflare's "under attack mode"
+driver.get('https://nowsecure.nl')   # my own test test site with max anti-bot protection
 
 ```
 
 
-### The Version 2 expert mode, including Devtool/Wire events!  ###
+### expert mode, including Devtool/Wire events  ###
 Literally, this is all you have to do. 
 You can now listen and subscribe to the low level devtools-protocol.
 I just recently found out that is also on planning for future release of the official chromedriver.
@@ -135,7 +147,7 @@ However i implemented my own for now. Since i needed it myself for investigation
 
 ```python
 
-import undetected_chromedriver.v2 as uc
+import undetected_chromedriver as uc
 from pprint import pformat
 
 driver = uc.Chrome(enable_cdp_events=True)

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -19,7 +19,7 @@ by UltrafunkAmsterdam (https://github.com/ultrafunkamsterdam)
 """
 
 
-__version__ = "3.1.5r4"
+__version__ = "3.1.6"
 
 
 import json
@@ -206,11 +206,12 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             now, in case you are nag-fetishist, or a diagnostics data feeder to google, you can set this to False.
             Note: if you don't handle the nag screen in time, the browser loses it's connection and throws an Exception.
 
-        use_subprocess: bool, optional , default: False,
+        use_subprocess: bool, optional , default: True,
 
             False (the default) makes sure Chrome will get it's own process (so no subprocess of chromedriver.exe or python
                 This fixes a LOT of issues, like multithreaded run, but mst importantly. shutting corectly after
                 program exits or using .quit()
+                you should be knowing what you're doing, and know how python works.
 
               unfortunately, there  is always an edge case in which one would like to write an single script with the only contents being:
               --start script--
@@ -222,7 +223,11 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
               and will be greeted with an error, since the program exists before chrome has a change to launch.
               in that case you can set this to `True`. The browser will start via subprocess, and will keep running most of times.
               ! setting it to True comes with NO support when being detected. !
-
+        
+        no_sandbox: bool, optional, default=True 
+             uses the --no-sandbox option, and additionally does suppress the "unsecure option" status bar
+             this option has a default of True since many people seem to run this as root (....) , and chrome does not start
+             when running as root without using --no-sandbox flag.
         """
         self.debug = debug
         patcher = Patcher(
@@ -346,6 +351,8 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
         if suppress_welcome:
             options.arguments.extend(["--no-default-browser-check", "--no-first-run"])
+        if no_sandbox:
+            options.arguments.extend(["--no-sandbox", "--test-type"])
         if headless or options.headless:
             options.headless = True
             options.add_argument("--window-size=1920,1080")

--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -119,6 +119,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         suppress_welcome=True,
         use_subprocess=False,
         debug=False,
+        no_sandbox=True,
         **kw
     ):
         """


### PR DESCRIPTION
- use_subprocess  now defaults to True since many people do not understand python's  multiprocessing and __name__ == '__main__' 
- added option "no_sandbox" with a default value of True since many people seem to run this as root (.......) ,  will run into errors since chrome does not run as root without using --no-  sandbox flag.  the downside was that you would get another warning bar about "using unsecure command line flag".   uc's no_sandbox option also makes sure this warning get's supressed.