### PR TITLE
Bug Fix on CentOS 7 - platform.endswith("linux") fails to match "linux2"

### DIFF
--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -29,7 +29,7 @@ class Patcher(object):
     if platform.endswith("win32"):
         zip_name %= "win32"
         exe_name %= ".exe"
-    if platform.endswith("linux"):
+    if platform.startswith("linux"):
         zip_name %= "linux64"
         exe_name %= ""
     if platform.endswith("darwin"):


### PR DESCRIPTION
Python sys.platform statement returns "linux2" instead "linux" on CentOS 7. 
The endswith statement fails to match this linux distro platform name.
Now using starstwith to correctly match platform name.