### PR TITLE
Fixed win 6 error when time.sleep(0.1)

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -740,7 +740,13 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 else:
                     logger.debug("successfully removed %s" % self.user_data_dir)
                     break
-                time.sleep(0.1)
+                try:
+                    time.sleep(0.1)
+                except (RuntimeError, OSError, PermissionError) as e:
+                    logger.debug(
+                        "When trying 'time.sleep(0.1)', a %s occured: %s\nretrying..."
+                        % (e.__class__.__name__, e)
+                    )
 
         # dereference patcher, so patcher can start cleaning up as well.
         # this must come last, otherwise it will throw 'in use' errors

--- a/undetected_chromedriver/devtool.py
+++ b/undetected_chromedriver/devtool.py
@@ -12,6 +12,8 @@ from typing import Callable
 from typing import List
 from typing import Optional
 
+logger = logging.getLogger("uc")
+logger.setLevel(logging.getLogger().getEffectiveLevel())
 
 class Structure(dict):
     """
@@ -162,7 +164,13 @@ def test():
                 "func called! %s  (args: %s, kwargs: %s)" % (fn.__name__, args, kwargs)
             )
             while driver.service.process and driver.service.process.poll() is not None:
-                time.sleep(0.1)
+                try:
+                    time.sleep(0.1)
+                except (RuntimeError, OSError, PermissionError) as e:
+                    logger.debug(
+                        "When trying 'time.sleep(0.1)', a %s occured: %s\nretrying..."
+                        % (e.__class__.__name__, e)
+                    )
             res = fn(*args, **kwargs)
             print("func completed! (result: %s)" % res)
             return res

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -268,8 +268,11 @@ class Patcher(object):
                     os.unlink(self.executable_path)
                     logger.debug("successfully unlinked %s" % self.executable_path)
                     break
-                except (OSError, RuntimeError, PermissionError):
-                    time.sleep(0.1)
+                except (OSError, RuntimeError, PermissionError) as e:
+                    logger.debug(
+                        "When trying 'time.sleep(0.1)', a %s occured: %s\nretrying..."
+                        % (e.__class__.__name__, e)
+                    )
                     continue
                 except FileNotFoundError:
                     break


### PR DESCRIPTION
Hey, Im using undetected_chromedriver and when Im using driver.quit() I get this error

\undetected_chromedriver_init_.py", line 744, in quit
time.sleep(0.1)
OSError: [WinError 6] Invalid handle