### PR TITLE
Fix `--window-size=X, Y` argument

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -286,6 +286,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
         # see if a custom user profile is specified in options
         for arg in options.arguments:
+         
 
             if any([_ in arg for _ in ("--headless", "headless")]):
                 options.arguments.remove(arg)
@@ -298,6 +299,15 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 except IndexError:
                     logger.debug("will set the language to en-US,en;q=0.9")
                     language = "en-US,en;q=0.9"
+                  
+            if "--window-size" in arg:
+                m = re.search("(?:--)?window-size(?:[ =])?(.*)", arg)
+                try:
+                    window_size= m[1]
+                    logger.debug(
+                        "window-size found in user argument %s => %s" % (arg, m[1])
+                    )
+                    keep_window_size = True
 
             if "user-data-dir" in arg:
                 m = re.search("(?:--)?user-data-dir(?:[ =])?(.*)", arg)
@@ -375,8 +385,8 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 options.add_argument("--headless=chrome")
             elif self.patcher.version_main >= 108:
                 options.add_argument("--headless=new")
-
-        options.add_argument("--window-size=1920,1080")
+        if not keep_window_size:
+            options.add_argument("--window-size=1920,1080")
         options.add_argument("--start-maximized")
         options.add_argument("--no-sandbox")
         # fixes "could not connect to chrome" error when running


### PR DESCRIPTION
Keep `--window-size` argument when specified in options.
Fixes https://github.com/ultrafunkamsterdam/undetected-chromedriver/issues/1100