### PR TITLE
chore: raise exception when chrome cannot be found

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -842,3 +842,5 @@ def find_chrome_executable():
     for candidate in candidates:
         if os.path.exists(candidate) and os.access(candidate, os.X_OK):
             return os.path.normpath(candidate)
+
+    raise RuntimeError("Could not automatically find the chrome executable. Please install chrome or chromium first, or specify browser_executable_path the options.")


### PR DESCRIPTION
I'm not sure if you accept contributions, but in any case a small PR to explicitly raise error when chrome cannot be found.  Hopefully this prevent the many duplicate issues concerning this issue.

If you don't have chrome installed, you get a stack trace similar to

```
  File "/app/src/modules/scrapers/base_scraper.py", line 137, in reset_driver
    self.driver = Chrome(
                  ^^^^^^^
  File "/app/prefect/.venv/lib/python3.11/site-packages/seleniumwire/undetected_chromedriver/webdriver.py", line 61, in __init__
    super().__init__(*args, **kwargs)
  File "/app/prefect/.venv/lib/python3.11/site-packages/undetected_chromedriver/__init__.py", line 421, in __init__
    browser = subprocess.Popen(
              ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.11/subprocess.py", line 1775, in _execute_child
    and os.path.dirname(executable)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 152, in dirname
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

