### PR TITLE
Fix #955 OSError: [WinError 6] The handle is invalid

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -752,7 +752,6 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 else:
                     logger.debug("successfully removed %s" % self.user_data_dir)
                     break
-                time.sleep(0.1)
 
         # dereference patcher, so patcher can start cleaning up as well.
         # this must come last, otherwise it will throw 'in use' errors


### PR DESCRIPTION
Fixes #955, #954
I don't know why, I don't want to know why, but removing `time.sleep(0.1)` fixes all `OSError: [WinError 6] The handle is invalid
` errors.