### PR TITLE
Fix of "OSError: [WinError 6] The handle is invalid"

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -782,7 +782,11 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 else:
                     logger.debug("successfully removed %s" % self.user_data_dir)
                     break
-                time.sleep(0.1)
+                
+                try:
+                    time.sleep(0.1)
+                except OSError:
+                    pass
 
         # dereference patcher, so patcher can start cleaning up as well.
         # this must come last, otherwise it will throw 'in use' errors


### PR DESCRIPTION
This error seems to be a problem for a lot of users of the package. Adding a try-except block is solving the issue for them while keeping it functional for the others as well.

Source: https://github.com/ultrafunkamsterdam/undetected-chromedriver/issues/955