### PR TITLE
Expose data_path in Patcher

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import typing
 from weakref import finalize
 
 import selenium.webdriver.chrome.service
@@ -124,6 +125,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         debug=False,
         no_sandbox=True,
         user_multi_procs: bool = False,
+        data_path: typing.Optional[str] = None,
         **kw,
     ):
         """
@@ -252,6 +254,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             force=patcher_force_close,
             version_main=version_main,
             user_multi_procs=user_multi_procs,
+            data_path=data_path,
         )
         # self.patcher.auto(user_multiprocess = user_multi_num_procs)
         self.patcher.auto()

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -8,10 +8,10 @@ import os
 import pathlib
 import random
 import re
-import shutil
 import string
 import sys
 import time
+import typing
 from urllib.request import urlopen
 from urllib.request import urlretrieve
 import zipfile
@@ -57,6 +57,7 @@ class Patcher(object):
         force=False,
         version_main: int = 0,
         user_multi_procs=False,
+        data_path: typing.Optional[str] = None,
     ):
         """
         Args:
@@ -67,6 +68,8 @@ class Patcher(object):
             version_main: 0 = auto
                 specify main chrome version (rounded, ex: 82)
         """
+        if data_path:
+            self.data_path = data_path
         self.force = force
         self._custom_exe_path = False
         prefix = "undetected"


### PR DESCRIPTION
Allows specifying the data_path for where to download undetected_chromedriver to.