### PR TITLE
3.5.2 - Minor changes and fixes

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -17,11 +17,12 @@ by UltrafunkAmsterdam (https://github.com/ultrafunkamsterdam)
 from __future__ import annotations
 
 
-__version__ = "3.5.1a"
+__version__ = "3.5.2"
 
 import json
 import logging
 import os
+import pathlib
 import re
 import shutil
 import subprocess
@@ -371,6 +372,18 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             options.binary_location = (
                 browser_executable_path or find_chrome_executable()
             )
+
+        if not options.binary_location or not \
+                pathlib.Path(options.binary_location).exists():
+                raise FileNotFoundError(
+                    "\n---------------------\n"
+                    "Could not determine browser executable."
+                    "\n---------------------\n"
+                    "Make sure your browser is installed in the default location (path).\n"
+                    "If you are sure about the browser executable, you can specify it using\n"
+                    "the `browser_executable_path='{}` parameter.\n\n"
+                    .format("/path/to/browser/executable" if IS_POSIX else "c:/path/to/your/browser.exe")
+                )
 
         self._delay = 3
 
@@ -877,8 +890,6 @@ def find_chrome_executable():
             if item is not None:
                 for subitem in (
                     "Google/Chrome/Application",
-                    "Google/Chrome Beta/Application",
-                    "Google/Chrome Canary/Application",
                 ):
                     candidates.add(os.sep.join((item, subitem, "chrome.exe")))
     for candidate in candidates:

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -111,18 +111,16 @@ class Patcher(object):
         Returns:
 
         """
-        # if self.user_multi_procs and \
-        #         self.user_multi_procs != -1:
-        #     # -1 being a skip value used later in this block
-        #
         p = pathlib.Path(self.data_path)
         if self.user_multi_procs:
             with Lock():
-                files = list(p.rglob("*chromedriver*?"))
-                for file in files:
-                    if self.is_binary_patched(file):
-                        self.executable_path = str(file)
-                        return True
+                files = list(p.rglob("*chromedriver*"))
+                most_recent = max(files, key=lambda f: f.stat().st_mtime)
+                files.remove(most_recent)
+                list(map(lambda f: f.unlink(), files))
+                if self.is_binary_patched(most_recent):
+                    self.executable_path = str(most_recent)
+                    return True
 
         if executable_path:
             self.executable_path = executable_path


### PR DESCRIPTION
* removed search paths for Chrome Canary and Chrome Beta from find_chrome_executable() since chromedriver is always behind schedule so that means a driver for newer versions than current main could not be found and raises Exception.

* Changed/Fixed wrong binary version caused by patcher. Due to multi-threading people and a mistake fromy my side, the driver binary currently on disk was always used instead of getting new ones. even if you did not use multithreading. so even outdated binaries where kept, hence many people got the dreaded "wrong version" error.
   - so for multithreading people, it now only keeps the most recent binary and throws away others. 
   - for normal people, you will get a fresh binary, like you deserve ;)

* Added more descriptive exceptions when Chrome binary could not be found origin no connection could be made to Chrome.

* some stuff i forgot, like bumping version on pypa so it installs correct version :)