### PR TITLE
Add backwards compatibility for Desired Capabilities

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -442,7 +442,11 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         self.options = options
 
         if not desired_capabilities:
-            desired_capabilities = options.to_capabilities()
+            desired_capabilities = {}
+
+        # Compatability for users/libraries still using desired_capabilities
+        for k, v in desired_capabilities.items():
+            options.set_capability(k, v)
 
         if not use_subprocess:
             self.browser_pid = start_detached(


### PR DESCRIPTION
This adds backward compatibility for libraries that use the desired_capabilities parameter (such as selenium-wire). I have made a pull request in Selenium Wire to fix this (https://github.com/wkeeling/selenium-wire/pull/699), but that seems unlikely to be merged anytime soon. Instead, I thought to fix it here since it may help other libraries experiencing the same issues.