### PR TITLE
Add better checking for version_main when adding headless flag

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -396,16 +396,10 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
         if headless or options.headless:
-            #workaround until a better checking is found
-            try:
-                if self.patcher.version_main < 108:
-                    options.add_argument("--headless=chrome")
-                elif self.patcher.version_main >= 108:
-                    options.add_argument("--headless=new")
-            except:
-                logger.warning("could not detect version_main."
-                               "therefore, we are assuming it is chrome 108 or higher")
+            if not self.patcher.version_main or self.patcher.version_main >= 108:
                 options.add_argument("--headless=new")
+            else:
+                options.add_argument("--headless=chrome")
 
         options.add_argument("--window-size=1920,1080")
         options.add_argument("--start-maximized")


### PR DESCRIPTION
This probably should be how the version is checked. It gets rid of the logger warning message when version_main is None and works when users specify an integer.

Fixes many issues (#1096, #1109, #1141, #1179, #1200, #1301, and #1308) which technically should’ve already been closed because of the `try/except` block that was implemented.

This logic has been used by others in the issues above to fix it, but the PRs that implement this fix right now all seem to have logic that doesn't use the correct argument for every version. 