### PR TITLE
Added a log message about removing args

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -301,6 +301,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         for arg in options.arguments:
 
             if any([_ in arg for _ in ("--headless", "headless")]):
+                logger.info("Removing arg because it contains the substring headless: %s" % arg)
                 options.arguments.remove(arg)
                 options.headless = True
 


### PR DESCRIPTION
After banging my head a bit I realized that the reason headless mode was not working with a reused profile was because my profile path had the substring headless in it users/{username}/{headless,gui}.  This code should be refactored but I'm not sure of all of the logic so for now a log message should help point people in the right direction.