### PR TITLE
don't remove user_data_dir if it contains the substring headless

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -301,8 +301,9 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         for arg in options.arguments:
 
             if any([_ in arg for _ in ("--headless", "headless")]):
-                options.arguments.remove(arg)
-                options.headless = True
+                     if not arg.startswith("--user-data-dir="):
+                         options.arguments.remove(arg)
+                         options.headless = True
 
             if "lang" in arg:
                 m = re.search("(?:--)?lang(?:[ =])?(.*)", arg)


### PR DESCRIPTION
Fix for #1506 .  Should be able to use paths that contain the substring headless.  For example users/{username}/{headless,gui}