### PR TITLE
Fixed close driver issue for Python 3.10+

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -795,7 +795,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 else:
                     logger.debug("successfully removed %s" % self.user_data_dir)
                     break
-                time.sleep(0.1)
+                # time.sleep(0.1)
 
         # dereference patcher, so patcher can start cleaning up as well.
         # this must come last, otherwise it will throw 'in use' errors


### PR DESCRIPTION
Resolved Chrome driver close issue in Python 3.10+

The issue was arising when closing the Chrome driver in Python 3.10 and above, resulting in an 'OSError: [WinError 6] The handle is invalid' error. The problem was traced to a sleep statement in the __init__.py file, which has been temporarily addressed by commenting out the time.sleep(0.1) line.

This pull request proposes the temporary fix as mentioned, with the aim of resolving the handle invalid error. Further investigation and refinement may be needed to find a more robust solution.

Please review and consider merging these changes. Thank you.