### PR TITLE
Update __init__.py

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -409,7 +409,6 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
         options.add_argument("--window-size=1920,1080")
         options.add_argument("--start-maximized")
-        options.add_argument("--no-sandbox")
         # fixes "could not connect to chrome" error when running
         # on linux using privileged user like root (which i don't recommend)
 


### PR DESCRIPTION
Delete the line that breaks the ability to choose whether to use Chrome's "--no-sandbox" argument or not. That functionality is already, and supposed to be achieved through "no_sandbox" argument in the "__init__" method of the UC's Chrome class.