### PR TITLE
Removed unused lock, allowing usage on Lambda

### DIFF
--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -25,7 +25,6 @@ IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2"))
 
 
 class Patcher(object):
-    lock = Lock()
     exe_name = "chromedriver%s"
 
     platform = sys.platform


### PR DESCRIPTION
Resolves #441, #772 and #975 

This line of code does nothing? and it's preventing undetected-chromedriver from working on AWS Lambda:
![image](https://github.com/ultrafunkamsterdam/undetected-chromedriver/assets/4060824/0ca21947-3885-4e40-82b8-a1234f7ee2ff)

I have made a minimal working example with this change so correct me if I'm wrong but removing this line doesn't break anything:
https://github.com/filipopo/undetected-chromedriver-lambda