### PR TITLE
Fix attribute error of options.headless

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -302,7 +302,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
             if any([_ in arg for _ in ("--headless", "headless")]):
                 options.arguments.remove(arg)
-                options.headless = True
+                headless = True
 
             if "lang" in arg:
                 m = re.search("(?:--)?lang(?:[ =])?(.*)", arg)
@@ -395,7 +395,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         if no_sandbox:
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
-        if headless or options.headless:
+        if headless:
             #workaround until a better checking is found
             try:
                 if self.patcher.version_main < 108:
@@ -485,7 +485,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         else:
             self._web_element_cls = WebElement
 
-        if options.headless:
+        if headless:
             self._configure_headless()
 
     def _configure_headless(self):


### PR DESCRIPTION
**Env**: windows11 + undetected-chromedriver 3.5.3 + selenium 4.13.0 + chrome 117
**Problem**:  When running the given example in readme:
```
import undetected_chromedriver as uc

driver = uc.Chrome()
driver.get('https://nowsecure.nl')
driver.save_screenshot('nowsecure.png')
```

I've got:
```
driver = uc.Chrome()
             ^^^^^^^^^^^
File "C:\Users\Gaspard\anaconda3\envs\Scrapy\Lib\site-packages\undetected_chromedriver\__init__.py", line 398, in __init__
    if headless or options.headless:
                   ^^^^^^^^^^^^^^^^
AttributeError: 'ChromeOptions' object has no attribute 'headless'
```
**Solution**
Now that there is little difference between headless and options.headless, it's suggested to use headless only.