### PR TITLE
fixed options not having headless attribute

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -395,7 +395,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         if no_sandbox:
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
-        if headless or options.headless:
+        if headless or (hasattr(options, 'headless') and options.headless):
             #workaround until a better checking is found
             try:
                 if self.patcher.version_main < 108:
@@ -406,7 +406,9 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 logger.warning("could not detect version_main."
                                "therefore, we are assuming it is chrome 108 or higher")
                 options.add_argument("--headless=new")
-
+        else:
+            options.headless = False
+            
         options.add_argument("--window-size=1920,1080")
         options.add_argument("--start-maximized")
         options.add_argument("--no-sandbox")


### PR DESCRIPTION
Fixes errors:

line 398, in __init__
    if headless or options.headless:
                   ^^^^^^^^^^^^^^^^
AttributeError: 'ChromeOptions' object has no attribute 'headless'


line 488, in __init__
    if options.headless:
       ^^^^^^^^^^^^^^^^
AttributeError: 'ChromeOptions' object has no attribute 'headless'


