### PR TITLE
Migrate looseversion to fix distutils issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+looseversion==1.3.0

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # this module is part of undetected_chromedriver
 
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 import io
 import json
 import logging


### PR DESCRIPTION
I've submitted a patch to quickly fix the LooseVersion issues stopping `undetected-chromedriver` working with >= Python 3.12.0 since `distutils` was deprecated. It uses a third party library without many stars, so there's a risk there, and if someone wants to fix it properly by replacing LooseVersion with a custom type that'd be awesome - this is just a quick fix to get things working if needed. 