### PR TITLE
add parameter: extra_chrome_arguments + dont set window size

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -408,12 +408,6 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                                "therefore, we are assuming it is chrome 108 or higher")
                 options.add_argument("--headless=new")
 
-        options.add_argument("--window-size=1920,1080")
-        options.add_argument("--start-maximized")
-        options.add_argument("--no-sandbox")
-        # fixes "could not connect to chrome" error when running
-        # on linux using privileged user like root (which i don't recommend)
-
         options.add_argument(
             "--log-level=%d" % log_level
             or divmod(logging.getLogger().getEffectiveLevel(), 10)[0]


### PR DESCRIPTION
adding a parameter for \*every\* chrome argument is stupid
so just accept a `extra_chrome_arguments` list

dont set window size
a 1920x1080 chrome window is too large for my 1024x768 vnc display
