### PR TITLE
Update __init__.py

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -840,7 +840,11 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             self.service.process.kill()
         except:  # noqa
             pass
-        self.quit()
+                 
+        try:
+            self.quit()
+        except OSError:
+            pass
 
     @classmethod
     def _ensure_close(cls, self):


### PR DESCRIPTION
Prevents annoying error while using with seleniumwire.

`Exception ignored in: <function Chrome.__del__ at 0x0000015A0ADFCB80>
Traceback (most recent call last):
  File "C:\Users\dupa\miniconda3\envs\snap\Lib\site-packages\undetected_chromedriver\__init__.py", line 824, in __del__
  File "C:\Users\dupa\miniconda3\envs\snap\Lib\site-packages\seleniumwire\webdriver.py", line 69, in quit
  File "C:\Users\dupa\miniconda3\envs\snap\Lib\site-packages\undetected_chromedriver\__init__.py", line 811, in quit
OSError: [WinError 6] The handle is invalid`

Seleniumwire is already calling quit() then it goes to __del__ and its trying to close again already closed process.