### PR TITLE
Update Dependency from "diskutils" to "packaging" for Python 3.12 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "selenium>=4.9.0",
         "requests",
         "websockets",
+        "packaging",
     ],
     package_data={"undetected_chromedriver": [os.path.join("example", "example.py")]},
     url="https://github.com/ultrafunkamsterdam/undetected-chromedriver",

--- a/undetected_chromedriver/patcher.py
+++ b/undetected_chromedriver/patcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # this module is part of undetected_chromedriver
 
-from distutils.version import LooseVersion
+from packaging import version
 import io
 import json
 import logging
@@ -173,7 +173,7 @@ class Patcher(object):
             pass
 
         release = self.fetch_release_number()
-        self.version_main = release.version[0]
+        self.version_main = release.major
         self.version_full = release
         self.unzip_package(self.fetch_package())
         return self.patch()
@@ -233,14 +233,14 @@ class Patcher(object):
         """
         Gets the latest major version available, or the latest major version of self.target_version if set explicitly.
         :return: version string
-        :rtype: LooseVersion
+        :rtype: packaging.version.Version
         """
         # Endpoint for old versions of Chromedriver (114 and below)
         if self.is_old_chromedriver:
             path = f"/latest_release_{self.version_main}"
             path = path.upper()
             logger.debug("getting release number from %s" % path)
-            return LooseVersion(urlopen(self.url_repo + path).read().decode())
+            return version.parse(urlopen(self.url_repo + path).read().decode())
 
         # Endpoint for new versions of Chromedriver (115+)
         if not self.version_main:
@@ -251,7 +251,7 @@ class Patcher(object):
                 response = conn.read().decode()
 
             last_versions = json.loads(response)
-            return LooseVersion(last_versions["channels"]["Stable"]["version"])
+            return version.parse(last_versions["channels"]["Stable"]["version"])
 
         # Fetch the latest minor version of the major version provided
         path = "/latest-versions-per-milestone-with-downloads.json"
@@ -260,14 +260,14 @@ class Patcher(object):
             response = conn.read().decode()
 
         major_versions = json.loads(response)
-        return LooseVersion(major_versions["milestones"][str(self.version_main)]["version"])
+        return version.parse(major_versions["milestones"][str(self.version_main)]["version"])
 
     def parse_exe_version(self):
         with io.open(self.executable_path, "rb") as f:
             for line in iter(lambda: f.readline(), b""):
                 match = re.search(rb"platform_handle\x00content\x00([0-9.]*)", line)
                 if match:
-                    return LooseVersion(match[1].decode())
+                    return version.parse(match[1].decode())
 
     def fetch_package(self):
         """
@@ -277,11 +277,11 @@ class Patcher(object):
         """
         zip_name = f"chromedriver_{self.platform_name}.zip"
         if self.is_old_chromedriver:
-            download_url = "%s/%s/%s" % (self.url_repo, self.version_full.vstring, zip_name)
+            download_url = "%s/%s/%s" % (self.url_repo, self.version_full, zip_name)
         else:
             zip_name = zip_name.replace("_", "-", 1)
             download_url = "https://storage.googleapis.com/chrome-for-testing-public/%s/%s/%s"
-            download_url %= (self.version_full.vstring, self.platform_name, zip_name)
+            download_url %= (self.version_full, self.platform_name, zip_name)
 
         logger.debug("downloading from %s" % download_url)
         return urlretrieve(download_url)[0]


### PR DESCRIPTION
Updated the patcher.py to use the "packaging" package instead of the now deprecated "diskutils" to ensure compatibility with Python 3.12, including the necessary adjustments in setup.py.