### PR TITLE
Fix file descriptor leak in service on quit().

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -763,7 +763,9 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
     def quit(self):
         try:
+            self.service.stop()
             self.service.process.kill()
+            self.command_executor.close()
             logger.debug("webdriver process ended")
         except (AttributeError, RuntimeError, OSError):
             pass


### PR DESCRIPTION
This PR ensures that the chromedriver service is closed gracefully in `quit()`, allowing the service to free any allocated file descriptors. If the service is simply killed, the file descriptors are not properly freed, eventually resulting in the "Too many open files" error in Linux.

Also see:
https://github.com/ultrafunkamsterdam/undetected-chromedriver/issues/1123
