### PR TITLE
Fixed a typo in __init__.py

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -499,8 +499,6 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                     "Page.addScriptToEvaluateOnNewDocument",
                     {
                         "source": """
-
-                           Object.defineProperty(window, "navigator", {
                                 Object.defineProperty(window, "navigator", {
                                   value: new Proxy(navigator, {
                                     has: (target, key) => (key === "webdriver" ? false : key in target),


### PR DESCRIPTION
Removed a duplicate line in cdp command code that prevents webdriver detection by website

https://github.com/ultrafunkamsterdam/undetected-chromedriver/blob/0aa5fbe252370b4cb2b95526add445392cad27ba/undetected_chromedriver/__init__.py#L503

Probably caused by a copy paste error in https://github.com/ultrafunkamsterdam/undetected-chromedriver/pull/1044?